### PR TITLE
썸띵

### DIFF
--- a/Assets/Script/Interaction/InteractionManager.cs
+++ b/Assets/Script/Interaction/InteractionManager.cs
@@ -19,7 +19,7 @@ public class InteractionManager : Singleton<InteractionManager>
 
     private void LazyInit()
     {
-        _InteractionDic = _InteractionDic ?? new Dictionary<int, InteractableObject>();
+        _InteractionDic ??= new Dictionary<int, InteractableObject>();
     }
     public bool IsInteractable(GameObject instance, out InteractableObject interactableObject)
     {

--- a/Assets/Script/Module/Item/ItemFinder.cs
+++ b/Assets/Script/Module/Item/ItemFinder.cs
@@ -10,7 +10,7 @@ public class ItemFinder : MonoBehaviour
     {
         if (_DroppedItems.Count == 0) return null;
 
-        Vector2 pos = transform.position;
+        Vector3 pos = transform.position;
 
         float closeLength = float.MaxValue;
         DroppedItem cloes = null;
@@ -24,7 +24,7 @@ public class ItemFinder : MonoBehaviour
                 i = next;
                 continue;
             }
-            float length = Vector2.Distance(i.Value.transform.position, pos);
+            float length = (pos - i.Value.transform.position).sqrMagnitude;
 
             if (length < closeLength)
             {
@@ -53,6 +53,7 @@ public class ItemFinder : MonoBehaviour
             if (i.Value.gameObject.GetInstanceID() == compareID)
             {
                 _DroppedItems.Remove(i);
+                break;
             }
         }
     }


### PR DESCRIPTION
### ItemFinder의 작동 최적화
- 가장 가까이있는 아이템을 찾을 때 Vector2.Distance를 사용하는 대신, sqrMagnitude를 사용하여
상대적인 거리를 비교하도록 한다.
- 영역에서 벗어난 아이템을 검색할 때, 찾게된 이후에는 더이상 불필요한 검색을 중단하도록 한다.

### InteractionManager의 딕셔너리를 초기화하는 코드를 단순화한다
- 복합형 할당식을 단순화한다!

### 오크 손도끼 아이템을 수정한다
- 불필요한 IEquipItem인터페이스를 사용하지 않는다.
- InteractionManager에 대한 참조를 대리자로 대체한다.
- 도끼 아이템의 능력을 구현할 때 사용하는 임시객체를 멤버로 변경한다.